### PR TITLE
Parameterize stimulation cost per well

### DIFF
--- a/src/geophires_x/Economics.py
+++ b/src/geophires_x/Economics.py
@@ -1619,7 +1619,7 @@ class Economics:
         )
 
         # TODO https://github.com/NREL/GEOPHIRES-X/issues/383?title=Parameterize+indirect+cost+factor
-        contingency_and_indirect_costs_tooltip = 'plus 15% contingency plus 12% indirect costs'
+        stimulation_contingency_and_indirect_costs_tooltip = 'plus 15% contingency plus 5% indirect costs'
 
         # noinspection SpellCheckingInspection
         self.Cstim = self.OutputParameterDict[self.Cstim.Name] = OutputParameter(
@@ -1628,10 +1628,16 @@ class Economics:
             PreferredUnits=CurrencyUnit.MDOLLARS,
             CurrentUnits=CurrencyUnit.MDOLLARS,
             ToolTipText=f'Default correlation: ${self.stimulation_cost_per_injection_well.value}M '
-                        f'per injection well {contingency_and_indirect_costs_tooltip}. '
-                        f'Provide {self.ccstimadjfactor.Name} to multiply the default correlation. '
-                        f'Provide {self.ccstimfixed.Name} to override the default correlation and set your own cost.'
+                        f'per injection well {stimulation_contingency_and_indirect_costs_tooltip}. '
+                        f'Provide {self.stimulation_cost_per_injection_well.Name} to set the correlation '
+                        f'cost per injection well. '
+                        f'Provide {self.ccstimadjfactor.Name} to multiply the correlation-calculated cost. '
+                        f'Provide {self.ccstimfixed.Name} to override the correlation and set your own '
+                        f'total stimulation cost.'
         )
+
+        # TODO https://github.com/NREL/GEOPHIRES-X/issues/383?title=Parameterize+indirect+cost+factor
+        contingency_and_indirect_costs_tooltip = 'plus 15% contingency plus 12% indirect costs'
 
         # See TODO re:parameterizing indirect costs at src/geophires_x/Economics.py:652
         #    (https://github.com/NREL/GEOPHIRES-X/issues/383)

--- a/src/geophires_x/Economics.py
+++ b/src/geophires_x/Economics.py
@@ -585,18 +585,38 @@ class Economics:
             Valid=False,
             ToolTipText="Total reservoir stimulation capital cost"
         )
+
+        max_stimulation_cost_per_well_MUSD = 100
         self.stimulation_cost_per_injection_well = \
           self.ParameterDict[self.stimulation_cost_per_injection_well.Name] = floatParameter(
             'Reservoir Stimulation Capital Cost per Injection Well',
             DefaultValue=1.25,
             Min=0,
-            Max=100,
+            Max=max_stimulation_cost_per_well_MUSD,
             UnitType=Units.CURRENCY,
             PreferredUnits=CurrencyUnit.MDOLLARS,
             CurrentUnits=CurrencyUnit.MDOLLARS,
             Provided=False,
             ToolTipText='Reservoir stimulation capital cost per injection well'
         )
+
+        stimulation_cost_per_production_well_default_value_MUSD = 0
+        stimulation_cost_per_production_well_default_value_note = \
+            '. By default, only the injection wells are assumed to be stimulated unless this parameter is provided.' \
+                if stimulation_cost_per_production_well_default_value_MUSD == 0 else ''
+        self.stimulation_cost_per_production_well = \
+          self.ParameterDict[self.stimulation_cost_per_production_well.Name] = floatParameter(
+            'Reservoir Stimulation Capital Cost per Production Well',
+            DefaultValue=stimulation_cost_per_production_well_default_value_MUSD,
+            Min=0,
+            Max=max_stimulation_cost_per_well_MUSD,
+            UnitType=Units.CURRENCY,
+            PreferredUnits=CurrencyUnit.MDOLLARS,
+            CurrentUnits=CurrencyUnit.MDOLLARS,
+            ToolTipText=f'Reservoir stimulation capital cost per production well'
+                        f'{stimulation_cost_per_production_well_default_value_note}'
+        )
+
         self.ccstimadjfactor = self.ParameterDict[self.ccstimadjfactor.Name] = floatParameter(
             "Reservoir Stimulation Capital Cost Adjustment Factor",
             DefaultValue=1.0,
@@ -607,7 +627,7 @@ class Economics:
             CurrentUnits=PercentUnit.TENTH,
             Provided=False,
             Valid=True,
-            ToolTipText="Multiplier for built-in reservoir stimulation capital cost correlation"
+            ToolTipText="Multiplier for reservoir stimulation capital cost correlation"
         )
         self.ccexplfixed = self.ParameterDict[self.ccexplfixed.Name] = floatParameter(
             "Exploration Capital Cost",
@@ -1629,8 +1649,9 @@ class Economics:
             CurrentUnits=CurrencyUnit.MDOLLARS,
             ToolTipText=f'Default correlation: ${self.stimulation_cost_per_injection_well.value}M '
                         f'per injection well {stimulation_contingency_and_indirect_costs_tooltip}. '
-                        f'Provide {self.stimulation_cost_per_injection_well.Name} to set the correlation '
-                        f'cost per injection well. '
+                        f'Provide {self.stimulation_cost_per_injection_well.Name} and '
+                        f'{self.stimulation_cost_per_production_well.Name} to set the correlation '
+                        f'costs per well. '
                         f'Provide {self.ccstimadjfactor.Name} to multiply the correlation-calculated cost. '
                         f'Provide {self.ccstimfixed.Name} to override the correlation and set your own '
                         f'total stimulation cost.'
@@ -2358,11 +2379,15 @@ class Economics:
         else:
             stim_cost_per_injection_well = self.stimulation_cost_per_injection_well.quantity().to(
                 self.Cstim.CurrentUnits).magnitude
+            stim_cost_per_production_well = self.stimulation_cost_per_production_well.quantity().to(
+                self.Cstim.CurrentUnits).magnitude
 
             # 1.15 for 15% contingency and 1.05 for 5% indirect costs
             # TODO https://github.com/NREL/GEOPHIRES-X/issues/383?title=Parameterize+indirect+cost+factor
-            self.Cstim.value = (stim_cost_per_injection_well
-                                * model.wellbores.ninj.value
+            self.Cstim.value = ((
+                                 stim_cost_per_injection_well * model.wellbores.ninj.value
+                                 + stim_cost_per_production_well * model.wellbores.nprod.value
+                                )
                                 * self.ccstimadjfactor.value
                                 * 1.05 * 1.15)
 

--- a/src/geophires_x/Outputs.py
+++ b/src/geophires_x/Outputs.py
@@ -478,7 +478,7 @@ class Outputs:
                 if model.economics.totalcapcost.Valid and model.wellbores.redrill.value > 0:
                     f.write(f'         Drilling and completion costs (for redrilling):{model.economics.Cwell.value:10.2f} ' + model.economics.Cwell.CurrentUnits.value + NL)
                     f.write(f'      Drilling and completion costs per redrilled well: {(model.economics.Cwell.value/(model.wellbores.nprod.value+model.wellbores.ninj.value)):10.2f} ' + model.economics.Cwell.CurrentUnits.value + NL)
-                    f.write(f'         Stimulation costs (for redrilling):            {model.economics.Cstim.value:10.2f} ' + model.economics.Cstim.CurrentUnits.value + NL)
+                    f.write(f'         Stimulation costs (for redrilling):            {econ.Cstim.value:10.2f} {econ.Cstim.CurrentUnits.value}\n')
                 if model.economics.RITCValue.value:
                     f.write(f'         {model.economics.RITCValue.display_name}:                         {-1*model.economics.RITCValue.value:10.2f} {model.economics.RITCValue.CurrentUnits.value}\n')
 

--- a/src/geophires_x_schema_generator/geophires-request.json
+++ b/src/geophires_x_schema_generator/geophires-request.json
@@ -1404,8 +1404,17 @@
       "minimum": 0,
       "maximum": 100
     },
+    "Reservoir Stimulation Capital Cost per Production Well": {
+      "description": "Reservoir stimulation capital cost per production well. By default, only the injection wells are assumed to be stimulated unless this parameter is provided.",
+      "type": "number",
+      "units": "MUSD",
+      "category": "Economics",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 100
+    },
     "Reservoir Stimulation Capital Cost Adjustment Factor": {
-      "description": "Multiplier for built-in reservoir stimulation capital cost correlation",
+      "description": "Multiplier for reservoir stimulation capital cost correlation",
       "type": "number",
       "units": "",
       "category": "Economics",

--- a/src/geophires_x_schema_generator/geophires-request.json
+++ b/src/geophires_x_schema_generator/geophires-request.json
@@ -1395,6 +1395,15 @@
       "minimum": 0,
       "maximum": 1000
     },
+    "Reservoir Stimulation Capital Cost per Injection Well": {
+      "description": "Reservoir stimulation capital cost per injection well",
+      "type": "number",
+      "units": "MUSD",
+      "category": "Economics",
+      "default": 1.25,
+      "minimum": 0,
+      "maximum": 100
+    },
     "Reservoir Stimulation Capital Cost Adjustment Factor": {
       "description": "Multiplier for built-in reservoir stimulation capital cost correlation",
       "type": "number",

--- a/src/geophires_x_schema_generator/geophires-result.json
+++ b/src/geophires_x_schema_generator/geophires-result.json
@@ -351,7 +351,7 @@
         "Drilling and completion costs per redrilled well": {},
         "Stimulation costs": {
           "type": "number",
-          "description": "Default correlation: $1.25M per injection well plus 15% contingency plus 5% indirect costs. Provide Reservoir Stimulation Capital Cost per Injection Well to set the correlation cost per injection well. Provide Reservoir Stimulation Capital Cost Adjustment Factor to multiply the correlation-calculated cost. Provide Reservoir Stimulation Capital Cost to override the correlation and set your own total stimulation cost.",
+          "description": "Default correlation: $1.25M per injection well plus 15% contingency plus 5% indirect costs. Provide Reservoir Stimulation Capital Cost per Injection Well and Reservoir Stimulation Capital Cost per Production Well to set the correlation costs per well. Provide Reservoir Stimulation Capital Cost Adjustment Factor to multiply the correlation-calculated cost. Provide Reservoir Stimulation Capital Cost to override the correlation and set your own total stimulation cost.",
           "units": "MUSD"
         },
         "Stimulation costs (for redrilling)": {},

--- a/src/geophires_x_schema_generator/geophires-result.json
+++ b/src/geophires_x_schema_generator/geophires-result.json
@@ -351,7 +351,7 @@
         "Drilling and completion costs per redrilled well": {},
         "Stimulation costs": {
           "type": "number",
-          "description": "Default correlation: $1.25M per injection well plus 15% contingency plus 12% indirect costs. Provide Reservoir Stimulation Capital Cost Adjustment Factor to multiply the default correlation. Provide Reservoir Stimulation Capital Cost to override the default correlation and set your own cost.",
+          "description": "Default correlation: $1.25M per injection well plus 15% contingency plus 5% indirect costs. Provide Reservoir Stimulation Capital Cost per Injection Well to set the correlation cost per injection well. Provide Reservoir Stimulation Capital Cost Adjustment Factor to multiply the correlation-calculated cost. Provide Reservoir Stimulation Capital Cost to override the correlation and set your own total stimulation cost.",
           "units": "MUSD"
         },
         "Stimulation costs (for redrilling)": {},


### PR DESCRIPTION
# Description

1. Parameterize existing injection well stimulation cost/default value ($1.25M/injection well)
2. Add production well stimulation cost parameter with default value = $0 (existing behavior)

# Testing & Verification
1. Existing tests unaffected - existing behavior retained backwards-compatibly
2. Added unit test verifying that specifying `Reservoir Stimulation Capital Cost per Production Well` = 1.25 doubles calculated stimulation costs before contingency & indirect costs